### PR TITLE
misc: modified aws ecs agent example to use aws native auth

### DIFF
--- a/aws-ecs-with-agent/agent-config.yaml
+++ b/aws-ecs-with-agent/agent-config.yaml
@@ -1,0 +1,17 @@
+infisical:
+  address: https://app.infisical.com
+  exit-after-auth: true
+auth:
+  type: aws-iam
+sinks:
+  - type: file
+    config:
+      path: /infisical-agent/access-token
+templates:
+  - template-content: |
+      {{- with secret "5655f4f5-332b-45f9-af06-8f493edff36f" "dev" "/" }}
+      {{- range . }}
+      {{ .Key }}={{ .Value }}
+      {{- end }}
+      {{- end }}
+    destination-path: /infisical-agent/secrets

--- a/aws-ecs-with-agent/terraform/ecs.tf
+++ b/aws-ecs-with-agent/terraform/ecs.tf
@@ -4,30 +4,24 @@ resource "aws_ecs_cluster" "main" {
   name = "cb-cluster"
 }
 
-data "template_file" "cb_app" {
-  template = file("./templates/ecs/cb_app.json.tpl")
-
-  vars = {
-    app_image          = var.app_image
-    sidecar_image      = var.sidecar_image
-    app_port           = var.app_port
-    fargate_cpu        = var.fargate_cpu
-    fargate_memory     = var.fargate_memory
-    aws_region         = var.aws_region
-    auth_client_id     = "<>"
-    auth_client_secret = "<>"
-    agent_config       = "<>"
-  }
-}
-
 resource "aws_ecs_task_definition" "app" {
   family                   = "cb-app-task"
   execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+  task_role_arn            = aws_iam_role.ecs_task_role.arn
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = 4096
   memory                   = 8192
-  container_definitions    = data.template_file.cb_app.rendered
+  container_definitions = templatefile("./templates/ecs/cb_app.json.tpl", {
+    app_image           = var.app_image
+    sidecar_image       = var.sidecar_image
+    app_port            = var.app_port
+    fargate_cpu         = var.fargate_cpu
+    fargate_memory      = var.fargate_memory
+    aws_region          = var.aws_region
+    machine_identity_id = "<>"
+    agent_config = base64encode(file("../agent-config.yaml"))
+  })
   volume {
     name = "infisical-efs"
     efs_volume_configuration {
@@ -56,6 +50,5 @@ resource "aws_ecs_service" "main" {
     container_port   = var.app_port
   }
 
-  depends_on = [aws_alb_listener.front_end, aws_iam_role_policy_attachment.ecs_task_execution_role]
+  depends_on = [aws_alb_listener.front_end, aws_iam_role_policy_attachment.ecs_task_execution_role, aws_iam_role_policy_attachment.ecs_task_role]
 }
-

--- a/aws-ecs-with-agent/terraform/roles.tf
+++ b/aws-ecs-with-agent/terraform/roles.tf
@@ -2,8 +2,8 @@
 data "aws_iam_policy_document" "ecs_task_execution_role" {
   version = "2012-10-17"
   statement {
-    sid = ""
-    effect = "Allow"
+    sid     = ""
+    effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
     principals {
@@ -22,5 +22,32 @@ resource "aws_iam_role" "ecs_task_execution_role" {
 # ECS task execution role policy attachment
 resource "aws_iam_role_policy_attachment" "ecs_task_execution_role" {
   role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# ECS task role data
+data "aws_iam_policy_document" "ecs_task_role" {
+  version = "2012-10-17"
+  statement {
+    sid     = ""
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+# ECS task execution role
+resource "aws_iam_role" "ecs_task_role" {
+  name               = var.ecs_task_role_name
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_role.json
+}
+
+# ECS task execution role policy attachment
+resource "aws_iam_role_policy_attachment" "ecs_task_role" {
+  role       = aws_iam_role.ecs_task_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }

--- a/aws-ecs-with-agent/terraform/roles.tf
+++ b/aws-ecs-with-agent/terraform/roles.tf
@@ -40,13 +40,13 @@ data "aws_iam_policy_document" "ecs_task_role" {
   }
 }
 
-# ECS task execution role
+# ECS task role for AWS auth
 resource "aws_iam_role" "ecs_task_role" {
   name               = var.ecs_task_role_name
   assume_role_policy = data.aws_iam_policy_document.ecs_task_role.json
 }
 
-# ECS task execution role policy attachment
+# ECS task role policy attachment
 resource "aws_iam_role_policy_attachment" "ecs_task_role" {
   role       = aws_iam_role.ecs_task_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"

--- a/aws-ecs-with-agent/terraform/templates/ecs/cb_app.json.tpl
+++ b/aws-ecs-with-agent/terraform/templates/ecs/cb_app.json.tpl
@@ -58,12 +58,8 @@
     },
     "environment": [
       {
-        "name": "INFISICAL_UNIVERSAL_AUTH_CLIENT_ID",
-        "value": "${auth_client_id}"
-      },
-      {
-        "name": "INFISICAL_UNIVERSAL_CLIENT_SECRET",
-        "value": "${auth_client_secret}"
+        "name": "INFISICAL_MACHINE_IDENTITY_ID",
+        "value": "${machine_identity_id}"
       },
       {
         "name": "INFISICAL_AGENT_CONFIG_BASE64",

--- a/aws-ecs-with-agent/terraform/variables.tf
+++ b/aws-ecs-with-agent/terraform/variables.tf
@@ -10,6 +10,11 @@ variable "ecs_task_execution_role_name" {
   default     = "myEcsTaskExecutionRole"
 }
 
+variable "ecs_task_role_name" {
+  description = "ECS task role name"
+  default     = "myEcsTaskRole"
+}
+
 variable "az_count" {
   description = "Number of AZs to cover in a given region"
   default     = "2"
@@ -22,7 +27,7 @@ variable "app_image" {
 
 variable "sidecar_image" {
   description = "Infisical CLI with agent"
-  default     = "infisical/cli:0.16.10"
+  default     = "infisical/cli:0.28.5"
 }
 
 variable "app_port" {
@@ -48,4 +53,3 @@ variable "fargate_memory" {
   description = "Fargate instance memory to provision (in MiB)"
   default     = "2048"
 }
-

--- a/aws-ecs-with-agent/terraform/variables.tf
+++ b/aws-ecs-with-agent/terraform/variables.tf
@@ -27,7 +27,7 @@ variable "app_image" {
 
 variable "sidecar_image" {
   description = "Infisical CLI with agent"
-  default     = "infisical/cli:0.28.5"
+  default     = "infisical/cli:0.30.0"
 }
 
 variable "app_port" {


### PR DESCRIPTION
- This PR updates aws ecs agent example to use aws native auth
- This also includes modifying the example to use inline templates

This PR is dependent on https://github.com/Infisical/infisical/pull/2329